### PR TITLE
Added 150 ms delay for the scoll handler timeout for pecise scoll end emulation, as the result better scrolling performance on smartphones

### DIFF
--- a/ionic-image-lazy-load.js
+++ b/ionic-image-lazy-load.js
@@ -26,7 +26,7 @@ angular.module('ionicLazyLoad')
                     $timeout.cancel(scrollTimeoutId);
 
                     // wait and then invoke listeners (simulates stop event)
-                    scrollTimeoutId = $timeout($scope.invoke, 0);
+                    scrollTimeoutId = $timeout($scope.invoke, 150);
 
                 });
 


### PR DESCRIPTION
Hi Thanks a lot for the useful module for Ionic,

I've recently implemented the lazy loader for a news reader app. On desktop environment worked great.
However on the 'scroll' event listener for the ion-view caused slow scrolling performance on a hardware iPhone 5. Apparently the loader invoked after each scroll event fired.

I've dded 150 ms delay for the scroll handler timeout for precise scroll end emulation, as the result better scrolling performance on smartphones. Scrolling works great.

Cheers